### PR TITLE
fix: share trading state via app

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -1,131 +1,142 @@
-from fastapi import APIRouter, HTTPException
-from typing import Dict, Any
+from fastapi import APIRouter, HTTPException, Request
 import asyncio
 
 router = APIRouter()
 
-# 전역 변수 (main.py에서 설정됨)
-trading_client = None
-trading_strategy = None
 
-@router.get("/portfolio")
-async def get_portfolio():
-    """포트폴리오 현황 조회"""
+def get_trading_client(request: Request):
+    trading_client = getattr(request.app.state, "trading_client", None)
     if not trading_client:
         raise HTTPException(status_code=500, detail="Trading client not initialized")
-    
+    return trading_client
+
+
+def get_trading_strategy(request: Request):
+    trading_strategy = getattr(request.app.state, "trading_strategy", None)
+    if not trading_strategy:
+        raise HTTPException(status_code=500, detail="Trading strategy not initialized")
+    return trading_strategy
+
+
+@router.get("/portfolio")
+async def get_portfolio(request: Request):
+    """포트폴리오 현황 조회"""
+    trading_client = get_trading_client(request)
+
     try:
         balance = await trading_client.get_balance()
         current_price = await trading_client.get_current_price()
-        
-        # 총 자산 계산
+
         total_usd = 0
         for coin, data in balance.items():
             if coin == "BTC":
                 total_usd += data["balance"] * current_price
             elif coin == "USDT":
                 total_usd += data["balance"]
-        
+
         return {
             "balances": balance,
             "current_btc_price": current_price,
             "total_value_usd": total_usd,
-            "timestamp": asyncio.get_event_loop().time()
+            "timestamp": asyncio.get_event_loop().time(),
         }
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 @router.get("/trades")
-async def get_trade_history():
+async def get_trade_history(request: Request):
     """거래 내역 조회"""
-    if not trading_client:
-        raise HTTPException(status_code=500, detail="Trading client not initialized")
-    
+    trading_client = get_trading_client(request)
+
     try:
         trades = await trading_client.get_order_history()
         return {"trades": trades}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 @router.get("/price/{symbol}")
-async def get_price(symbol: str = "BTCUSDT"):
+async def get_price(request: Request, symbol: str = "BTCUSDT"):
     """특정 심볼 가격 조회"""
-    if not trading_client:
-        raise HTTPException(status_code=500, detail="Trading client not initialized")
-    
+    trading_client = get_trading_client(request)
+
     try:
         price = await trading_client.get_current_price(symbol)
         return {"symbol": symbol, "price": price}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 @router.get("/chart/{symbol}")
-async def get_chart_data(symbol: str = "BTCUSDT", interval: str = "1", limit: int = 100):
+async def get_chart_data(
+    request: Request, symbol: str = "BTCUSDT", interval: str = "1", limit: int = 100
+):
     """차트 데이터 조회"""
-    if not trading_client:
-        raise HTTPException(status_code=500, detail="Trading client not initialized")
-    
+    trading_client = get_trading_client(request)
+
     try:
         kline_data = await trading_client.get_kline_data(symbol, interval, limit)
-        
-        # 차트 형식으로 변환
+
         chart_data = []
         for kline in kline_data:
-            chart_data.append({
-                "timestamp": int(kline[0]),
-                "open": float(kline[1]),
-                "high": float(kline[2]),
-                "low": float(kline[3]),
-                "close": float(kline[4]),
-                "volume": float(kline[5])
-            })
-        
+            chart_data.append(
+                {
+                    "timestamp": int(kline[0]),
+                    "open": float(kline[1]),
+                    "high": float(kline[2]),
+                    "low": float(kline[3]),
+                    "close": float(kline[4]),
+                    "volume": float(kline[5]),
+                }
+            )
+
         return {"symbol": symbol, "data": chart_data}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 @router.post("/trading/start")
-async def start_trading():
+async def start_trading(request: Request):
     """자동매매 시작"""
-    if not trading_strategy:
-        raise HTTPException(status_code=500, detail="Trading strategy not initialized")
-    
+    trading_strategy = get_trading_strategy(request)
+
     if trading_strategy.is_active:
         return {"message": "Trading is already active"}
-    
-    # 백그라운드에서 실행
+
     asyncio.create_task(trading_strategy.start_trading())
     return {"message": "Auto-trading started"}
 
+
 @router.post("/trading/stop")
-async def stop_trading():
+async def stop_trading(request: Request):
     """자동매매 중지"""
-    if not trading_strategy:
-        raise HTTPException(status_code=500, detail="Trading strategy not initialized")
-    
+    trading_strategy = get_trading_strategy(request)
+
     trading_strategy.stop_trading()
     return {"message": "Auto-trading stopped"}
 
+
 @router.get("/trading/status")
-async def get_trading_status():
+async def get_trading_status(request: Request):
     """자동매매 상태 조회"""
-    if not trading_strategy:
-        raise HTTPException(status_code=500, detail="Trading strategy not initialized")
-    
+    trading_strategy = get_trading_strategy(request)
     return trading_strategy.get_strategy_status()
+
 
 @router.post("/order")
 async def place_manual_order(
+    request: Request,
     symbol: str = "BTCUSDT",
     side: str = "Buy",
-    qty: str = "0.001"
+    qty: str = "0.001",
 ):
     """수동 주문"""
-    if not trading_client:
-        raise HTTPException(status_code=500, detail="Trading client not initialized")
-    
+    trading_client = get_trading_client(request)
+
     try:
         result = await trading_client.place_order(symbol, side, "Market", qty)
         return result
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,60 +21,64 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# 글로벌 변수
-trading_client = None
-trading_strategy = None
 active_connections: list[WebSocket] = []
+
 
 @app.on_event("startup")
 async def startup_event():
     """앱 시작시 초기화"""
-    global trading_client, trading_strategy
-    
+
     # Bybit 클라이언트 초기화
-    trading_client = BybitClient()
-    trading_strategy = TradingStrategy(trading_client)
-    
+    app.state.trading_client = BybitClient()
+    app.state.trading_strategy = TradingStrategy(app.state.trading_client)
+
     print("🚀 Bitcoin Auto-Trading System 시작됨")
+
 
 @app.get("/")
 async def root():
     return {"message": "Bitcoin Auto-Trading API", "status": "running"}
 
+
 @app.get("/api/status")
 async def get_status():
     """시스템 상태 조회"""
+    trading_strategy = getattr(app.state, "trading_strategy", None)
     return {
         "status": "active",
         "timestamp": datetime.now().isoformat(),
-        "trading_active": trading_strategy.is_active if trading_strategy else False
+        "trading_active": trading_strategy.is_active if trading_strategy else False,
     }
+
 
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
     """실시간 데이터 WebSocket"""
     await websocket.accept()
     active_connections.append(websocket)
-    
+
     try:
         while True:
-            # 실시간 데이터 전송
+            trading_client = getattr(app.state, "trading_client", None)
             data = {
                 "timestamp": datetime.now().isoformat(),
                 "price": await trading_client.get_current_price() if trading_client else 0,
-                "balance": await trading_client.get_balance() if trading_client else {}
+                "balance": await trading_client.get_balance() if trading_client else {},
             }
             await websocket.send_text(json.dumps(data))
             await asyncio.sleep(1)  # 1초마다 업데이트
-            
+
     except Exception as e:
         print(f"WebSocket 연결 오류: {e}")
     finally:
         active_connections.remove(websocket)
 
+
 # API 라우터 포함
 app.include_router(router, prefix="/api")
+
 
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)
+


### PR DESCRIPTION
## Summary
- share trading client and strategy via FastAPI app state
- access trading state from routes through request

## Testing
- `python -m py_compile backend/main.py backend/api/routes.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac88a71ce8832ea82e9539c2d729c3