### PR TITLE
fix: track trades for signals and pnl

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -155,6 +155,15 @@ async def place_manual_order(
 
     try:
         result = await trading_client.place_order(symbol, side, "Market", qty)
+        if result.get("success"):
+            current_price = await trading_client.get_current_price(symbol)
+            trade_tracker.add_trade(
+                symbol,
+                side,
+                float(qty),
+                current_price,
+                signal="manual",
+            )
         return result
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,7 +6,7 @@ import json
 from datetime import datetime
 from typing import Dict, Any
 
-from api.routes import router
+from api.routes import router, trade_tracker
 from trading.bybit_client import BybitClient
 from trading.simple_strategy import TradingStrategy
 
@@ -30,7 +30,10 @@ async def startup_event():
 
     # Bybit 클라이언트 초기화
     app.state.trading_client = BybitClient()
-    app.state.trading_strategy = TradingStrategy(app.state.trading_client)
+    app.state.trade_tracker = trade_tracker
+    app.state.trading_strategy = TradingStrategy(
+        app.state.trading_client, trade_tracker
+    )
 
     print("🚀 Bitcoin Auto-Trading System 시작됨")
 


### PR DESCRIPTION
## Summary
- track trades via `TradeTracker` so dashboard shows signals and PnL
- record manual orders in trade tracker
- wire trade tracker into app startup

## Testing
- `python -m py_compile backend/trading/simple_strategy.py backend/main.py backend/api/routes.py`


------
https://chatgpt.com/codex/tasks/task_b_68ada0cbe040832e95bb875f19e9c32a