### PR TITLE
feat: add strategy configuration & control page

### DIFF
--- a/frontend/app/auth/page.tsx
+++ b/frontend/app/auth/page.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import AuthPage from '@/components/AuthPage'
+
+export default function Auth() {
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) {
+    return (
+      <div className="min-h-screen w-full flex items-center justify-center bg-navy-bg">
+        <div className="w-10 h-10 border-2 border-electric-blue border-t-transparent rounded-full animate-spin"></div>
+      </div>
+    )
+  }
+
+  return <AuthPage />
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -8,6 +8,12 @@
   }
 }
 
+@layer utilities {
+  .text-glow {
+    text-shadow: 0 0 10px rgba(30, 148, 246, 0.5);
+  }
+}
+
 /* Custom scrollbar for terminal look */
 .scrollbar-hide::-webkit-scrollbar {
   display: none;
@@ -17,8 +23,21 @@
   scrollbar-width: none;
 }
 
+/* Thin scrollbar for webkit */
+::-webkit-scrollbar {
+  width: 4px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: #202e3b;
+  border-radius: 4px;
+}
+
 .glass-panel {
-  background: rgba(22, 32, 42, 0.8);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  background: rgba(24, 35, 46, 0.8);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.05);
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -23,6 +23,10 @@ export default function RootLayout({
           rel="stylesheet"
         />
         <link
+          href="https://fonts.googleapis.com/icon?family=Material+Icons+Round"
+          rel="stylesheet"
+        />
+        <link
           href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
           rel="stylesheet"
         />

--- a/frontend/app/strategy/page.tsx
+++ b/frontend/app/strategy/page.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import StrategyPage from '@/components/StrategyPage'
+
+export default function Strategy() {
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) {
+    return (
+      <div className="min-h-screen w-full flex items-center justify-center bg-background-dark">
+        <div className="w-10 h-10 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>
+      </div>
+    )
+  }
+
+  return <StrategyPage />
+}

--- a/frontend/components/AuthPage.tsx
+++ b/frontend/components/AuthPage.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { setAdminKey, validateAdminKey, isAuthenticated } from '@/utils/auth'
+
+export default function AuthPage() {
+  const router = useRouter()
+  const [key, setKey] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // If already authenticated, go straight to dashboard
+  useEffect(() => {
+    if (isAuthenticated()) {
+      router.replace('/')
+    }
+  }, [router])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!key.trim()) {
+      setError('Please enter an access key')
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const isValid = await validateAdminKey(key.trim())
+      if (isValid) {
+        setAdminKey(key.trim())
+        router.push('/')
+      } else {
+        setError('Invalid access key. Attempt logged.')
+      }
+    } catch {
+      setError('Connection failed. Please try again.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="w-full min-h-screen bg-navy-bg font-display flex flex-col items-center justify-center p-6 text-slate-200">
+      <div className="w-full max-w-sm flex flex-col items-center">
+        {/* Logo */}
+        <div className="flex items-center gap-3 mb-12">
+          <div className="w-10 h-10 rounded-lg bg-electric-blue flex items-center justify-center text-white font-bold text-xl shadow-lg shadow-blue-500/20">
+            Q
+          </div>
+          <span className="font-bold text-2xl tracking-tight text-white">DataQuantLab</span>
+        </div>
+
+        {/* Auth Card */}
+        <div className="w-full bg-card-navy border border-slate-800 rounded-card p-8 shadow-2xl relative overflow-hidden">
+          {/* Top gradient line */}
+          <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-transparent via-electric-blue to-transparent opacity-50"></div>
+
+          {/* Lock icon + title */}
+          <div className="flex flex-col items-center mb-8">
+            <div className="w-12 h-12 rounded-full bg-slate-800/50 flex items-center justify-center mb-4">
+              <span className="material-symbols-outlined text-slate-400 text-2xl">lock</span>
+            </div>
+            <h2 className="text-lg font-semibold text-white tracking-wide">System Authentication</h2>
+            <p className="text-xs text-slate-500 mt-1 uppercase tracking-widest">Restricted Research Node</p>
+          </div>
+
+          {/* Form */}
+          <form className="space-y-6" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <label
+                className="text-[10px] font-bold text-slate-500 uppercase tracking-[0.2em] ml-1"
+                htmlFor="admin_key"
+              >
+                Admin_Key
+              </label>
+              <div className="relative group">
+                <input
+                  className="w-full bg-slate-900/50 border border-slate-700 rounded-lg py-4 px-4 text-white placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-electric-blue focus:border-electric-blue transition-all font-mono text-sm"
+                  id="admin_key"
+                  name="admin_key"
+                  placeholder="Enter restricted access key..."
+                  type="password"
+                  value={key}
+                  onChange={(e) => {
+                    setKey(e.target.value)
+                    setError(null)
+                  }}
+                  autoFocus
+                />
+              </div>
+              {error && (
+                <p className="text-xs text-red-400 ml-1 mt-1">{error}</p>
+              )}
+            </div>
+
+            <button
+              className="w-full bg-electric-blue hover:bg-blue-600 text-white font-bold py-4 rounded-lg transition-all shadow-lg shadow-blue-500/10 flex items-center justify-center gap-2 group disabled:opacity-50 disabled:cursor-not-allowed"
+              type="submit"
+              disabled={isLoading}
+            >
+              {isLoading ? (
+                <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+              ) : (
+                <>
+                  <span className="text-sm uppercase tracking-widest">Access Terminal</span>
+                  <span className="material-symbols-outlined text-sm group-hover:translate-x-1 transition-transform">
+                    arrow_forward
+                  </span>
+                </>
+              )}
+            </button>
+          </form>
+
+          {/* Info footer */}
+          <div className="mt-8 pt-6 border-t border-slate-800/50">
+            <div className="flex gap-3">
+              <span className="material-symbols-outlined text-slate-600 text-sm mt-0.5">info</span>
+              <p className="text-[11px] leading-relaxed text-slate-500 italic">
+                Restricted Access Environment. Unauthorized entry attempts are logged and reported to the system security protocol.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Bottom status */}
+        <div className="mt-12 flex flex-col items-center gap-2">
+          <span className="text-[10px] text-slate-600 uppercase tracking-widest">Quantum Engine v4.0.2</span>
+          <div className="flex items-center gap-2">
+            <div className="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse"></div>
+            <span className="text-[10px] text-slate-500 uppercase tracking-widest font-medium">
+              Encrypted Connection Active
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/MetricCards.tsx
+++ b/frontend/components/MetricCards.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import Link from 'next/link'
+
 interface TradingStatus {
   is_active: boolean
   strategy_name?: string
@@ -39,8 +41,8 @@ export default function MetricCards({
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-      {/* Strategy Card */}
-      <div className="bg-card-dark rounded-xl p-5 border border-slate-700/60 shadow-sm relative overflow-hidden group">
+      {/* Strategy Card - Clickable link to /strategy */}
+      <Link href="/strategy" className="bg-card-dark rounded-xl p-5 border border-slate-700/60 shadow-sm relative overflow-hidden group cursor-pointer hover:border-primary/40 transition-colors">
         <div className="absolute top-0 right-0 p-4 opacity-10 group-hover:opacity-20 transition-opacity">
           <span className="material-icons text-6xl text-primary">psychology</span>
         </div>
@@ -53,8 +55,11 @@ export default function MetricCards({
           <span className={`px-2 py-1 rounded text-xs font-bold ${isActive ? 'bg-green-500/10 text-green-400 border border-green-500/20' : 'bg-red-500/10 text-red-400 border border-red-500/20'}`}>
             {isActive ? 'ACTIVE' : 'STOPPED'}
           </span>
+          <span className="text-xs text-slate-500 group-hover:text-primary transition-colors flex items-center gap-0.5">
+            Details <span className="material-icons text-xs">arrow_forward</span>
+          </span>
         </div>
-      </div>
+      </Link>
 
       {/* Position Card */}
       <div className="bg-card-dark rounded-xl p-5 border border-slate-700/60 shadow-sm">

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -1,10 +1,17 @@
 'use client'
 
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
 interface SidebarProps {
   serverOnline: boolean
 }
 
 export default function Sidebar({ serverOnline }: SidebarProps) {
+  const pathname = usePathname()
+  const isHome = pathname === '/'
+  const isStrategy = pathname === '/strategy'
+
   return (
     <>
       {/* Mobile Top Header */}
@@ -17,14 +24,14 @@ export default function Sidebar({ serverOnline }: SidebarProps) {
 
       {/* Mobile Bottom Nav */}
       <nav className="md:hidden fixed bottom-0 w-full bg-card-dark border-t border-slate-800 z-50 flex justify-around py-3 px-2">
-        <button className="flex flex-col items-center gap-1 text-primary">
+        <Link href="/" className={`flex flex-col items-center gap-1 ${isHome ? 'text-primary' : 'text-slate-500 hover:text-primary/70'}`}>
           <span className="material-icons text-2xl">dashboard</span>
           <span className="text-xxs font-medium uppercase tracking-wider">Dash</span>
-        </button>
-        <button className="flex flex-col items-center gap-1 text-slate-500 hover:text-primary/70">
+        </Link>
+        <Link href="/strategy" className={`flex flex-col items-center gap-1 ${isStrategy ? 'text-primary' : 'text-slate-500 hover:text-primary/70'}`}>
           <span className="material-icons text-2xl">candlestick_chart</span>
           <span className="text-xxs font-medium uppercase tracking-wider">Strats</span>
-        </button>
+        </Link>
         <button className="flex flex-col items-center gap-1 text-slate-500 hover:text-primary/70">
           <span className="material-icons text-2xl">history</span>
           <span className="text-xxs font-medium uppercase tracking-wider">Backtest</span>
@@ -43,14 +50,14 @@ export default function Sidebar({ serverOnline }: SidebarProps) {
             <span className="font-bold text-lg tracking-tight hidden lg:block text-white">DataQuantLab</span>
           </div>
           <nav className="flex flex-col gap-2">
-            <a className="flex items-center gap-3 px-3 py-3 rounded-lg bg-primary/10 text-primary border border-primary/20" href="#">
+            <Link href="/" className={`flex items-center gap-3 px-3 py-3 rounded-lg transition-colors ${isHome ? 'bg-primary/10 text-primary border border-primary/20' : 'text-slate-400 hover:text-white hover:bg-slate-800'}`}>
               <span className="material-icons">dashboard</span>
               <span className="hidden lg:block font-medium">Overview</span>
-            </a>
-            <a className="flex items-center gap-3 px-3 py-3 rounded-lg text-slate-400 hover:text-white hover:bg-slate-800 transition-colors" href="#">
+            </Link>
+            <Link href="/strategy" className={`flex items-center gap-3 px-3 py-3 rounded-lg transition-colors ${isStrategy ? 'bg-primary/10 text-primary border border-primary/20' : 'text-slate-400 hover:text-white hover:bg-slate-800'}`}>
               <span className="material-icons">candlestick_chart</span>
               <span className="hidden lg:block font-medium">Active Strategies</span>
-            </a>
+            </Link>
             <a className="flex items-center gap-3 px-3 py-3 rounded-lg text-slate-400 hover:text-white hover:bg-slate-800 transition-colors" href="#">
               <span className="material-icons">analytics</span>
               <span className="hidden lg:block font-medium">Analytics</span>

--- a/frontend/components/StrategyPage.tsx
+++ b/frontend/components/StrategyPage.tsx
@@ -1,0 +1,378 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { tradingApi } from '@/utils/api'
+
+interface StrategyStatus {
+  strategy?: string
+  is_active: boolean
+  position: string | null
+  last_signal: string | null
+  trade_amount: string
+  trailing_stop?: number | null
+  bars_since_trade?: number
+  parameters?: Record<string, any>
+  parameter_descriptions?: Record<string, string>
+}
+
+interface PerformanceData {
+  daily_change_percent: number
+  weekly_change_percent: number
+  monthly_change_percent: number
+}
+
+interface PositionSummary {
+  total_trades?: number
+  winning_trades?: number
+  losing_trades?: number
+  win_rate?: number
+  total_pnl?: number
+  total_pnl_percent?: number
+  max_drawdown_percent?: number
+  avg_trade_pnl?: number
+}
+
+interface LatestTrade {
+  timestamp: string
+  side: string
+  symbol: string
+  price: number
+  qty: number
+}
+
+// Maps param keys to Material Icons Round names
+const PARAM_ICONS: Record<string, string> = {
+  symbol: 'currency_bitcoin',
+  interval: 'schedule',
+  lookback_bars: 'history',
+  ema_fast_period: 'speed',
+  ema_slow_period: 'slow_motion_video',
+  min_trend_gap_pct: 'functions',
+  atr_period: 'show_chart',
+  initial_stop_atr_mult: 'security',
+  trailing_stop_atr_mult: 'trending_down',
+  loop_seconds: 'timer',
+  cooldown_bars: 'hourglass_bottom',
+  rsi_period: 'analytics',
+  rsi_oversold: 'arrow_downward',
+  rsi_overbought: 'arrow_upward',
+  ma_short: 'speed',
+  ma_long: 'slow_motion_video',
+}
+
+// Human-friendly parameter labels
+const PARAM_LABELS: Record<string, string> = {
+  symbol: 'Symbol',
+  interval: 'Interval',
+  lookback_bars: 'Lookback Period',
+  ema_fast_period: 'EMA Fast Period',
+  ema_slow_period: 'EMA Slow Period',
+  min_trend_gap_pct: 'Min Trend Gap %',
+  atr_period: 'ATR Period',
+  initial_stop_atr_mult: 'Initial Stop (ATR x)',
+  trailing_stop_atr_mult: 'Trailing Stop (ATR x)',
+  loop_seconds: 'Loop Interval (s)',
+  cooldown_bars: 'Cooldown Bars',
+  rsi_period: 'RSI Period',
+  rsi_oversold: 'RSI Oversold',
+  rsi_overbought: 'RSI Overbought',
+  ma_short: 'MA Short',
+  ma_long: 'MA Long',
+}
+
+// Strategy descriptions
+const STRATEGY_DESCRIPTIONS: Record<string, string> = {
+  regime_trend:
+    'Trend-following strategy using a dual EMA regime filter. Enters long positions when the fast EMA crosses above the slow EMA by a minimum gap, and uses ATR-based trailing stops for risk management.',
+  simple:
+    'RSI and moving-average crossover strategy. Buys when RSI is oversold and short MA crosses above long MA. Sells when RSI is overbought or short MA crosses below long MA.',
+}
+
+// Strategy display names
+const STRATEGY_NAMES: Record<string, string> = {
+  regime_trend: 'Regime Trend Engine',
+  simple: 'Simple RSI-MA Strategy',
+}
+
+function formatTime(timestamp: string): string {
+  try {
+    const d = new Date(timestamp)
+    return d.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' })
+  } catch {
+    return timestamp
+  }
+}
+
+function formatPrice(n: number): string {
+  return n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+function formatParamValue(key: string, value: any): string {
+  if (typeof value === 'number') {
+    if (key.includes('pct') || key.includes('percent')) return `${(value * 100).toFixed(2)}%`
+    if (key.includes('mult')) return `${value}x`
+    if (Number.isInteger(value)) return value.toString()
+    return value.toFixed(3)
+  }
+  return String(value)
+}
+
+// Highlight params that are tuning knobs vs config params
+function isHighlightParam(key: string): boolean {
+  const highlights = [
+    'ema_fast_period', 'ema_slow_period', 'min_trend_gap_pct',
+    'atr_period', 'initial_stop_atr_mult', 'trailing_stop_atr_mult',
+    'rsi_period', 'rsi_oversold', 'rsi_overbought', 'ma_short', 'ma_long',
+  ]
+  return highlights.includes(key)
+}
+
+export default function StrategyPage() {
+  const router = useRouter()
+  const [status, setStatus] = useState<StrategyStatus | null>(null)
+  const [performance, setPerformance] = useState<PerformanceData | null>(null)
+  const [summary, setSummary] = useState<PositionSummary | null>(null)
+  const [latestTrade, setLatestTrade] = useState<LatestTrade | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  const fetchAll = useCallback(async () => {
+    try {
+      const [statusRes, perfRes, summaryRes, tradesRes] = await Promise.allSettled([
+        tradingApi.getTradingStatus(),
+        tradingApi.getPortfolioPerformance(),
+        tradingApi.getPositionsSummary(),
+        tradingApi.getTradeHistory(),
+      ])
+
+      if (statusRes.status === 'fulfilled') setStatus(statusRes.value)
+      if (perfRes.status === 'fulfilled') setPerformance(perfRes.value)
+      if (summaryRes.status === 'fulfilled') setSummary(summaryRes.value)
+      if (tradesRes.status === 'fulfilled') {
+        const trades = tradesRes.value.trades || []
+        if (trades.length > 0) setLatestTrade(trades[0])
+      }
+    } catch {
+      // keep existing data
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchAll()
+    const interval = setInterval(fetchAll, 15000)
+    return () => clearInterval(interval)
+  }, [fetchAll])
+
+  if (isLoading) {
+    return (
+      <div className="flex w-full min-h-screen items-center justify-center bg-background-dark">
+        <div className="w-10 h-10 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>
+      </div>
+    )
+  }
+
+  const isActive = status?.is_active || false
+  const strategyKey = status?.strategy || 'regime_trend'
+  const strategyName = STRATEGY_NAMES[strategyKey] || strategyKey
+  const description = STRATEGY_DESCRIPTIONS[strategyKey] || 'Automated trading strategy.'
+  const params = status?.parameters || {}
+  const paramDescs = status?.parameter_descriptions || {}
+
+  const totalReturn = performance?.monthly_change_percent || 0
+  const totalReturnPositive = totalReturn >= 0
+  const winRate = summary?.win_rate || 0
+  const totalTrades = summary?.total_trades || 0
+  const maxDD = summary?.max_drawdown_percent || 0
+
+  return (
+    <div className="w-full min-h-screen bg-background-dark text-slate-200 font-display flex flex-col antialiased">
+      {/* Header */}
+      <header className="px-5 py-4 flex items-center justify-between sticky top-0 z-40 bg-background-dark/90 backdrop-blur-sm border-b border-white/5">
+        <button
+          onClick={() => router.push('/')}
+          className="w-10 h-10 rounded-full flex items-center justify-center bg-surface-highlight text-slate-400 hover:text-white transition-colors"
+        >
+          <span className="material-icons-round">arrow_back</span>
+        </button>
+        <div className="flex flex-col items-center">
+          <h1 className="text-lg font-bold tracking-tight">Strategy Control</h1>
+          <span className="text-xs text-primary font-medium tracking-wide uppercase opacity-80">
+            {strategyKey.toUpperCase()}
+          </span>
+        </div>
+        <div className="w-10 h-10" /> {/* Spacer for centering */}
+      </header>
+
+      {/* Main Content */}
+      <main className="flex-1 px-5 pb-32 overflow-y-auto space-y-6 max-w-2xl mx-auto w-full">
+        {/* Title & Status Badge */}
+        <div className="flex items-start justify-between mt-4">
+          <div>
+            <h2 className="text-2xl font-bold text-white leading-tight">{strategyName}</h2>
+            <p className="text-sm text-slate-400 mt-1">
+              {params.symbol || 'BTCUSDT'} &bull; {params.interval || '15'}m interval
+            </p>
+          </div>
+          <div className={`flex items-center gap-2 px-3 py-1.5 rounded-full ${isActive ? 'bg-success/10 border border-success/20' : 'bg-danger/10 border border-danger/20'}`}>
+            <span className={`w-2 h-2 rounded-full ${isActive ? 'bg-success animate-pulse shadow-[0_0_8px_rgba(34,197,94,0.6)]' : 'bg-danger'}`}></span>
+            <span className={`text-xs font-bold tracking-wider uppercase ${isActive ? 'text-success' : 'text-danger'}`}>
+              {isActive ? 'Live' : 'Stopped'}
+            </span>
+          </div>
+        </div>
+
+        {/* Performance Summary Card */}
+        <div className="glass-panel rounded-xl p-5 shadow-lg relative overflow-hidden group">
+          <div className="absolute -right-10 -top-10 w-40 h-40 bg-primary/10 rounded-full blur-3xl group-hover:bg-primary/20 transition-all duration-700"></div>
+          <div className="flex justify-between items-center mb-6">
+            <h3 className="text-sm font-semibold text-slate-400 uppercase tracking-wider">Performance Metrics</h3>
+          </div>
+          <div className="grid grid-cols-2 gap-6 mb-6">
+            {/* Total Return */}
+            <div>
+              <p className="text-xs text-slate-500 mb-1">Monthly Return</p>
+              <div className="flex items-baseline gap-2">
+                <span className={`text-3xl font-bold ${totalReturnPositive ? 'text-success' : 'text-danger'}`}>
+                  {totalReturnPositive ? '+' : ''}{totalReturn.toFixed(1)}%
+                </span>
+                <span className={`material-icons-round text-sm ${totalReturnPositive ? 'text-success' : 'text-danger'}`}>
+                  {totalReturnPositive ? 'trending_up' : 'trending_down'}
+                </span>
+              </div>
+            </div>
+            {/* Win Rate as Sharpe-style hero number */}
+            <div>
+              <p className="text-xs text-slate-500 mb-1">Win Rate</p>
+              <div className="flex items-baseline gap-2">
+                <span className="text-3xl font-bold text-primary text-glow">
+                  {winRate.toFixed(1)}%
+                </span>
+              </div>
+            </div>
+          </div>
+          <div className="grid grid-cols-3 gap-4 border-t border-white/5 pt-4">
+            <div>
+              <p className="text-[10px] text-slate-500 uppercase tracking-wide">Max DD</p>
+              <span className="text-sm font-semibold text-danger">
+                {maxDD !== 0 ? `-${Math.abs(maxDD).toFixed(1)}%` : '-'}
+              </span>
+            </div>
+            <div>
+              <p className="text-[10px] text-slate-500 uppercase tracking-wide">Position</p>
+              <span className="text-sm font-semibold text-white">
+                {status?.position || 'None'}
+              </span>
+            </div>
+            <div>
+              <p className="text-[10px] text-slate-500 uppercase tracking-wide">Trades</p>
+              <span className="text-sm font-semibold text-white">
+                {totalTrades.toLocaleString()}
+              </span>
+            </div>
+          </div>
+          <div className="absolute bottom-0 left-0 right-0 h-1 bg-gradient-to-r from-transparent via-success/50 to-transparent opacity-50"></div>
+        </div>
+
+        {/* Active/Paused Toggle (visual only - shows current state) */}
+        <div className="bg-surface rounded-lg p-1.5 flex shadow-inner border border-white/5">
+          <div className={`flex-1 py-3 px-4 rounded-md font-semibold text-sm transition-all duration-300 flex items-center justify-center gap-2 ${isActive ? 'bg-primary shadow-glow text-white' : 'text-slate-500'}`}>
+            <span className="material-icons-round text-base">play_circle</span>
+            Active
+          </div>
+          <div className={`flex-1 py-3 px-4 rounded-md font-medium text-sm transition-all duration-300 flex items-center justify-center gap-2 ${!isActive ? 'bg-danger/20 text-danger' : 'text-slate-500'}`}>
+            <span className="material-icons-round text-base">pause_circle</span>
+            Paused
+          </div>
+        </div>
+
+        {/* Rule Description */}
+        <div className="space-y-3">
+          <h3 className="text-sm font-semibold text-slate-300 px-1">Logic Description</h3>
+          <div className="glass-panel rounded-lg p-5">
+            <div className="flex gap-4">
+              <div className="mt-1 w-8 h-8 rounded-full bg-primary/20 flex items-center justify-center flex-shrink-0 text-primary">
+                <span className="material-icons-round text-lg">psychology</span>
+              </div>
+              <p className="text-sm leading-relaxed text-slate-300">{description}</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Parameters List */}
+        <div className="space-y-3">
+          <div className="flex justify-between items-end px-1">
+            <h3 className="text-sm font-semibold text-slate-300">Parameters</h3>
+          </div>
+          <div className="bg-surface rounded-xl overflow-hidden border border-white/5 divide-y divide-white/5">
+            {Object.entries(params).map(([key, value]) => {
+              const icon = PARAM_ICONS[key] || 'settings'
+              const label = PARAM_LABELS[key] || key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+              const desc = paramDescs[key] || ''
+              const highlight = isHighlightParam(key)
+
+              return (
+                <div key={key} className="p-4 flex items-center justify-between group hover:bg-white/5 transition-colors">
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 rounded bg-background-dark flex items-center justify-center text-slate-500">
+                      <span className="material-icons-round text-lg">{icon}</span>
+                    </div>
+                    <div>
+                      <p className="text-sm font-medium text-white">{label}</p>
+                      {desc && <p className="text-xs text-slate-500 max-w-[200px] truncate">{desc}</p>}
+                    </div>
+                  </div>
+                  <div className={`font-mono px-3 py-1 rounded text-sm font-bold ${highlight ? 'text-primary bg-primary/10 border border-primary/20' : 'text-white bg-surface-highlight'}`}>
+                    {formatParamValue(key, value)}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Latest Execution */}
+        <div className="space-y-3 pt-2">
+          <h3 className="text-sm font-semibold text-slate-300 px-1">Latest Execution</h3>
+          {latestTrade ? (
+            <div className="bg-surface/50 border border-white/5 rounded-lg p-3 flex items-center justify-between text-xs">
+              <div className="flex items-center gap-2">
+                <span className="text-slate-500">{formatTime(latestTrade.timestamp)}</span>
+                <span className={`font-bold ${latestTrade.side?.toLowerCase() === 'buy' ? 'text-success' : 'text-danger'}`}>
+                  {latestTrade.side?.toUpperCase()}
+                </span>
+                <span className="text-white">{latestTrade.symbol || 'BTC-USD'}</span>
+              </div>
+              <span className="font-mono text-slate-300">@ {formatPrice(latestTrade.price)}</span>
+            </div>
+          ) : (
+            <div className="bg-surface/50 border border-white/5 rounded-lg p-3 text-xs text-slate-500 text-center">
+              No executions yet
+            </div>
+          )}
+        </div>
+      </main>
+
+      {/* Bottom Action Bar */}
+      <div className="fixed bottom-0 left-0 right-0 p-5 bg-background-dark/80 backdrop-blur-xl border-t border-white/5 z-50">
+        <div className="flex gap-4 max-w-2xl mx-auto">
+          <button
+            onClick={() => router.push('/')}
+            className="flex-1 py-4 bg-surface hover:bg-surface-highlight text-white rounded-lg font-semibold text-sm transition-colors border border-white/10 flex items-center justify-center gap-2 group"
+          >
+            <span className="material-icons-round text-slate-400 group-hover:text-white transition-colors">dashboard</span>
+            Dashboard
+          </button>
+          <button
+            onClick={() => router.push('/')}
+            className="flex-1 py-4 bg-primary hover:bg-primary/90 text-white rounded-lg font-semibold text-sm shadow-glow transition-all transform active:scale-95 flex items-center justify-center gap-2"
+          >
+            <span className="material-icons-round">history</span>
+            View Logs
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -17,6 +17,9 @@ module.exports = {
         'surface-highlight': '#202e3b',
         'success': '#22c55e',
         'danger': '#ef4444',
+        'navy-bg': '#0B1120',
+        'card-navy': '#111827',
+        'electric-blue': '#2563eb',
       },
       fontFamily: {
         'display': ['Space Grotesk', 'sans-serif'],
@@ -26,6 +29,9 @@ module.exports = {
       },
       boxShadow: {
         'glow': '0 0 15px rgba(30, 148, 246, 0.3)',
+      },
+      borderRadius: {
+        'card': '12px',
       },
     },
   },

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -13,12 +13,19 @@ module.exports = {
         'background-dark': '#101a22',
         'card-dark': '#16202a',
         'card-darker': '#0d141a',
+        'surface': '#18232e',
+        'surface-highlight': '#202e3b',
+        'success': '#22c55e',
+        'danger': '#ef4444',
       },
       fontFamily: {
         'display': ['Space Grotesk', 'sans-serif'],
       },
       fontSize: {
         'xxs': '0.65rem',
+      },
+      boxShadow: {
+        'glow': '0 0 15px rgba(30, 148, 246, 0.3)',
       },
     },
   },

--- a/frontend/utils/auth.ts
+++ b/frontend/utils/auth.ts
@@ -1,0 +1,58 @@
+import api from './api'
+
+const AUTH_STORAGE_KEY = 'dql_admin_key'
+
+export function getAdminKey(): string | null {
+  if (typeof window === 'undefined') return null
+  return sessionStorage.getItem(AUTH_STORAGE_KEY)
+}
+
+export function setAdminKey(key: string): void {
+  sessionStorage.setItem(AUTH_STORAGE_KEY, key)
+  // Set default header for all future requests
+  api.defaults.headers.common['X-API-KEY'] = key
+}
+
+export function clearAdminKey(): void {
+  sessionStorage.removeItem(AUTH_STORAGE_KEY)
+  delete api.defaults.headers.common['X-API-KEY']
+}
+
+export function isAuthenticated(): boolean {
+  return !!getAdminKey()
+}
+
+/** Restore the header from sessionStorage (call on app init) */
+export function restoreAuthHeader(): void {
+  const key = getAdminKey()
+  if (key) {
+    api.defaults.headers.common['X-API-KEY'] = key
+  }
+}
+
+/**
+ * Validate the key against the backend by calling a protected endpoint.
+ * Returns true if the key is accepted, false otherwise.
+ */
+export async function validateAdminKey(key: string): Promise<boolean> {
+  try {
+    // Temporarily set the header for this request
+    const response = await api.get('/api/trading/status', {
+      headers: { 'X-API-KEY': key },
+    })
+    return response.status === 200
+  } catch {
+    // trading/status is public, so try a protected endpoint instead
+    try {
+      await api.post('/api/positions/update-prices', null, {
+        headers: { 'X-API-KEY': key },
+      })
+      return true
+    } catch (err: any) {
+      // 401 means wrong key, anything else means key might be fine but endpoint errored
+      if (err?.response?.status === 401) return false
+      // If we get 500 or other, the key was accepted (auth passed) but something else failed
+      return err?.response?.status !== 401
+    }
+  }
+}


### PR DESCRIPTION
Add /strategy route with a detailed strategy control page that displays live parameters, performance metrics, and latest execution data from the backend API. The strategy card on the dashboard and the sidebar now navigate to this new page.